### PR TITLE
ci: automate Docusaurus documentation build

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -41,7 +41,7 @@ jobs:
           node-version: 18
 
       - name: Install dependencies
-        run: pnpm --config.pm-on-fail=ignore install --frozen-lockfile --ignore-scripts
+        run: pnpm install --frozen-lockfile
 
       - name: Build Docusaurus
-        run: pnpm --config.pm-on-fail=ignore build
+        run: pnpm build

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,0 +1,47 @@
+name: Build documentation
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs-build.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs-build.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.4.1
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: pnpm --config.pm-on-fail=ignore install --frozen-lockfile --ignore-scripts
+
+      - name: Build Docusaurus
+        run: pnpm --config.pm-on-fail=ignore build

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 24
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,13 +5,13 @@ This website is built using [Docusaurus](https://docusaurus.io/), a modern stati
 ### Installation
 
 ```
-$ yarn
+$ pnpm install --frozen-lockfile
 ```
 
 ### Local Development
 
 ```
-$ yarn start
+$ pnpm start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
@@ -19,7 +19,7 @@ This command starts a local development server and opens up a browser window. Mo
 ### Build
 
 ```
-$ yarn build
+$ pnpm build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
@@ -29,13 +29,13 @@ This command generates static content into the `build` directory and can be serv
 Using SSH:
 
 ```
-$ USE_SSH=true yarn deploy
+$ USE_SSH=true pnpm deploy
 ```
 
 Not using SSH:
 
 ```
-$ GIT_USER=<Your GitHub username> yarn deploy
+$ GIT_USER=<Your GitHub username> pnpm deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.

--- a/docs/package.json
+++ b/docs/package.json
@@ -43,5 +43,6 @@
   },
   "engines": {
     "node": ">=18.0"
-  }
+  },
+  "packageManager": "pnpm@10.4.1"
 }


### PR DESCRIPTION
## Summary

- add a pull-request and main-branch workflow for the Docusaurus documentation build
- use the repository's pnpm lockfile and pnpm 10.4.1
- use supported Node.js LTS 24 for the documentation workflow
- keep the workflow read-only and separate from deployment

## Implementation

- `.github/workflows/docs-build.yml`
- `docs/README.md`
- `docs/package.json`

The docs subproject has `pnpm-lock.yaml` and no `yarn.lock`. The workflow uses Node 24 and pnpm 10.4.1, with frozen installation and a Docusaurus build.

## Clean environment validation

The exact PR tree was exported with `git archive` into a Linux Node 24 container:

- `node --version` (`v24.19.0`) — PASS
- `pnpm --version` (`10.4.1`) — PASS
- `cd docs && pnpm install --frozen-lockfile` — PASS
- `pnpm run build` — PASS

The clean run proved that the project is compatible with Node 24. A Node 22 fallback was not required. Local-only `pm-on-fail=ignore` and `--ignore-scripts` workarounds are unnecessary and remain removed.

## Final gates

- workflow YAML parse — PASS
- `git diff --check` — PASS
- secret scan of changed files — PASS
- `permissions: contents: read` only — PASS
- no `pull_request_target`, secrets, write permissions, or deploy changes
- `.github/workflows/static.yml` unchanged

Closes #58